### PR TITLE
Add 'locales/' folder to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "files": [
     "lib/",
+    "locales/",
     "README.md",
     "changelog.md",
     "index.js"


### PR DESCRIPTION
The npm documentation for this package includes the example 
```
var instance = timeDelta.create({
  locale: 'en' // default
});
```

However, the `locales/` folder is not currently shipped with the package, so the above code will fail.
This MR fixes this.