### PR TITLE
Fix format function types - improve requireLocale error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Formats difference between two dates as a human-readable string in almost any la
 
 ### Node.js
 
-In Node.js environment library will load requested locales automatically.
+In Node.js environment library will load requested locales automatically from a relative path.
 
 ```js
 const timeDelta = require('time-delta');
@@ -76,7 +76,8 @@ timeDelta.addLocale([enLocale, ruLocale]);
 
 // Creating an instance
 const instance = timeDelta.create({
-  locale: 'en', // default
+  locale: 'en',
+  autoloadLocales: false
 });
 
 const date1 = new Date('2015-04-01T21:00:00');

--- a/README.md
+++ b/README.md
@@ -63,16 +63,22 @@ This ensures minimal size of your application bundle.
 ```js
 // Importing the library
 import * as timeDelta from 'time-delta';
+import * as numerous from 'numerous';
 
 // Importing locales that you want to use
 import enLocale from 'time-delta/locales/en';
+import numerousEnLocale from 'numerous/locales/en';
 import ruLocale from 'time-delta/locales/ru';
+import numerousRuLocale from 'numerous/locales/ru';
 
 // Registering locale
 timeDelta.addLocale(enLocale);
+numerous.addLocale(numerousEnLocale);
+
 
 // You can register multiple locales
 timeDelta.addLocale([enLocale, ruLocale]);
+timeDelta.addLocale([numerousEnLocale, numerousRuLocale]);
 
 // Creating an instance
 const instance = timeDelta.create({

--- a/lib/time-delta.js
+++ b/lib/time-delta.js
@@ -211,7 +211,9 @@ function requireLocale(localeId) {
     );
 
   } catch (error) {
-    throw Error(`Failed to load locale: ${localeId}`);
+    throw Error(
+      `Failed to load locale: ${localeId} from ../locales/${localeId}.js. If using a bundled time-delta, set 'autoloadLocales: false' in the config: ${error}`
+    );
 
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@ export interface Locale {
 }
 
 export interface Formatter {
-  format(firstDate: Date, secondDate: Date, options?: Config);
+  format(firstDate: Date, secondDate: Date, options?: Config): string;
 }
 
 export function create(config?: Config): Formatter;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,11 +25,18 @@ export interface Locale {
 }
 
 export interface Formatter {
+  /**
+   *  Returns difference between two dates as a text string.
+   */
   format(firstDate: Date | number, secondDate: Date | number, options?: Config): string;
 }
 
 export function create(config?: Config): Formatter;
 
+/**
+ * Adds pluralization data for the specified locale.
+ * Should be called in browser.
+ */
 export function addLocale(localeData: (Locale | Locale[]));
 
 export const defaultConfig: Config;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@ export interface Locale {
 }
 
 export interface Formatter {
-  format(firstDate: Date, secondDate: Date, options?: Config): string;
+  format(firstDate: Date | number, secondDate: Date | number, options?: Config): string;
 }
 
 export function create(config?: Config): Formatter;


### PR DESCRIPTION
- fix: fix the return type of format
- fix: accept number in format
- fix: add missing docstring to the types
- fix: fix the error caused by using bundled time-delta in node env
- fix: add missing numerous locale registrations needed in the browser code



Fixes #7 









